### PR TITLE
Fix char format warnings

### DIFF
--- a/src/RdvReader.cpp
+++ b/src/RdvReader.cpp
@@ -26,10 +26,10 @@ bool RdvReader::Read(string path, vtkPolyData *polyData)
     while(in.getline(s, 1000))
     {
         char time[20];
-        sscanf(s, "%s", &time);
+        sscanf(s, "%s", time);
 
         float f, x, y, z, v;
-        sscanf(s, "%s%f%f%f%f%f%f", &time, &f, &f, &x, &y, &z, &v);
+        sscanf(s, "%s%f%f%f%f%f%f", time, &f, &f, &x, &y, &z, &v);
 
         points->InsertNextPoint(x, y, z);
 


### PR DESCRIPTION
Original warnings:
  format ‘%s’ expects argument of type ‘char_’,
       but argument 3 has type ‘char (_)[20]’ [-Wformat=]
  sscanf(s, "%s", &time);
